### PR TITLE
Fixs the Ad problem.

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
     flag.StringVar(&handler.quality, "q", "720p", "set resolution(shorthand)")
     flag.Parse()
 
+    isPremium := handler.cookie != ""
     handler.askForSN()
     handler.getDeviceId()
     handler.gainAccess()
@@ -43,9 +44,11 @@ func main() {
     handler.checkLock()
     handler.unlock()
     handler.unlock()
-    handler.startAd()
-    time.Sleep(3 * time.Second)
-    handler.skipAd()
+    if !isPremium {
+	handler.startAd()
+	time.Sleep(8 * time.Second)
+	handler.skipAd()
+    }
     handler.videoStart()
     handler.checkNoAd()
     handler.getM3U8()


### PR DESCRIPTION
Bahamut seems like changes their approach to dealing with Ad,
So, I extend the waiting time to 30 second to solve this problem temporarily.

It looks like Bahamut create a <user, start_time> mapping to record the time on their machine to 
avoid user easily skip the Ad.