### PR TITLE
Fix normal user can't see the anime which require login. Closes #13

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ type bahamut struct {
     quality   string
     res       string
     tmp       string
+    isPremium bool
 }
 
 func main() {
@@ -36,18 +37,18 @@ func main() {
     flag.StringVar(&handler.quality, "q", "720p", "set resolution(shorthand)")
     flag.Parse()
 
-    isPremium := handler.cookie != ""
     handler.askForSN()
     handler.getDeviceId()
     handler.gainAccess()
+    handler.checkPremium()
     handler.unlock()
     handler.checkLock()
     handler.unlock()
     handler.unlock()
-    if !isPremium {
-	handler.startAd()
-	time.Sleep(8 * time.Second)
-	handler.skipAd()
+    if !handler.isPremium {
+	    handler.startAd()
+	    time.Sleep(8 * time.Second)
+	    handler.skipAd()
     }
     handler.videoStart()
     handler.checkNoAd()

--- a/token.go
+++ b/token.go
@@ -92,6 +92,26 @@ func (h *bahamut) gainAccess() {
     }
 }
 
+func (h *bahamut) checkPremium() {
+    resp := h.request("checkPremium", "https://ani.gamer.com.tw/ajax/token.php?sn="+h.sn+"&device="+h.deviceId+"&hash="+randomString(12))
+
+    defer resp.Body.Close()
+    body, err := ioutil.ReadAll(resp.Body)
+    isErr("Read response failed -", err)
+
+    var bahaData map[string]interface{}
+    err = json.Unmarshal(body, &bahaData)
+    isErr("Parse json failed -", err)
+
+    if bahaData["vip"] != nil && bahaData["vip"].(bool) == true {
+        h.isPremium = true;
+        fmt.Println("Is Premium user")
+    } else {
+        h.isPremium = false;
+        fmt.Println("Not a Premium user")
+    }
+}
+
 func (h *bahamut) checkNoAd() {
     resp := h.request("checkNoAd", "https://ani.gamer.com.tw/ajax/token.php?sn="+h.sn+"&device="+h.deviceId+"&hash="+randomString(12))
 


### PR DESCRIPTION
fix the issue #13 

add the `checkPremium()` in token.go, that's similar to `checkNoAd()`.