### PR TITLE
Fix the time of AD changed and get m3u8 failed

### DIFF
--- a/download.go
+++ b/download.go
@@ -36,7 +36,7 @@ func (h *bahamut) getM3U8() {
     isErr("Parse json failed -", err)
 
     if bahaData["src"].(string) != "" {
-        h.mUrl = "https:" + bahaData["src"].(string)
+        h.mUrl = bahaData["src"].(string)
     } else {
         isErr("Please try again -", errors.New("src not found"))
     }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
     handler.unlock()
     if !handler.isPremium {
         handler.startAd()
-        time.Sleep(8 * time.Second)
+        time.Sleep(20 * time.Second)
         handler.skipAd()
     }
     handler.videoStart()


### PR DESCRIPTION
The time of AD change to 20 sec fix the problem,
and remove the redundant "https:" in url, which
cause the getM3U8 failed.